### PR TITLE
simplify circle config and use node12 instead of node8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,24 @@
 version: 2
 
-# References to reduce duplication in the rest of the config
-references:
-  container: &container_config
-    docker:
-      - image: circleci/node:8
-  cache_key: &cache_key
-    dependency-cache-{{ checksum "package.json" }}
-  cache_node_modules: &cache_node_modules
-    save_cache:
-      key: *cache_key
-      paths:
-        - node_modules
-  restore_node_modules: &restore_node_modules
-    restore_cache:
-      keys:
-        - *cache_key
-
 # Circle jobs
 jobs:
 
-  # Verify code then run unit and integration tests
+  # Verify code and run tests
   test:
-    <<: *container_config
+    docker:
+      - image: circleci/node:12
     steps:
       - checkout
-      - *restore_node_modules
-      - run:
-          name: Install dependencies
-          command: npm install
-      - *cache_node_modules
-      - run:
-          name: Run linters
-          command: make verify
-      - run:
-          name: Run tests
-          command: make test
+      - run: npm ci
+      - run: npm test
 
   # Publish the module to npm
   publish:
-    <<: *container_config
+    docker:
+      - image: circleci/node:12
     steps:
       - checkout
-      - *restore_node_modules
+      - run: npm ci
       - run:
           name: Authenticate with npm
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc


### PR DESCRIPTION
no longer cache anything in circle
use `npm ci` to ensure package-lock.json is aligned with package.json file
use `npm test` as this uses `make verify test` under the hood
use node12 which is LTS and not node8