### PR TITLE
Add Github Action to auto approve dependabot

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,13 @@
+name: Auto Approve Dependabot PRs
+
+on:
+  pull_request
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/auto-approve-action@v2.0.0
+      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      with:
+        github-token: "${{ secrets.ORIGAMI_FOX_ACCESS_TOKEN }}"


### PR DESCRIPTION
So it may auto-merge dev dependencies: https://github.com/Financial-Times/origami/issues/55